### PR TITLE
Misleading media path on build

### DIFF
--- a/config/webpack.config.demo.js
+++ b/config/webpack.config.demo.js
@@ -127,7 +127,9 @@ module.exports = {
             loader: require.resolve('url-loader'),
             options: {
               limit: 10000,
-              name: 'media/[name].[ext]'
+              name: '[name].[ext]',
+              outputPath: 'media/',
+              publicPath: '../'
             }
           },
           // Process JS with Babel.
@@ -210,7 +212,9 @@ module.exports = {
             // by webpacks internal loaders.
             exclude: [/\.js$/, /\.html$/, /\.json$/],
             options: {
-              name: 'media/[name].[ext]'
+              name: '[name].[ext]',
+              outputPath: 'media/',
+              publicPath: '../'
             }
           }
           // ** STOP ** Are you adding a new loader?

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -133,7 +133,9 @@ module.exports = {
             loader: require.resolve('url-loader'),
             options: {
               limit: 10000,
-              name: 'static/media/[name].[hash:8].[ext]',
+              name: '[name].[hash:8].[ext]',
+              outputPath: 'static/media/',
+              publicPath: '../'
             },
           },
           // Process JS with Babel.
@@ -198,7 +200,9 @@ module.exports = {
             exclude: [/\.js$/, /\.html$/, /\.json$/],
             loader: require.resolve('file-loader'),
             options: {
-              name: 'static/media/[name].[hash:8].[ext]',
+              name: '[name].[hash:8].[ext]',
+              outputPath: 'static/media/',
+              publicPath: '../'
             },
           },
         ],

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -126,7 +126,9 @@ module.exports = {
             loader: require.resolve('url-loader'),
             options: {
               limit: 10000,
-              name: 'media/[name].[ext]',
+              name: '[hash].[ext]',
+              outputPath: 'media/',
+              publicPath: '../'
             },
           },
           // Process JS with Babel.
@@ -210,7 +212,9 @@ module.exports = {
             // by webpacks internal loaders.
             exclude: [/\.js$/, /\.html$/, /\.json$/],
             options: {
-              name: 'media/[name].[ext]',
+              name: '[hash].[ext]',
+              outputPath: 'media/',
+              publicPath: '../'
             },
           },
           // ** STOP ** Are you adding a new loader?


### PR DESCRIPTION
Howdy, I have noticed a strange behaviour when building the project both for demo and production (when I uploaded my library in the registry), there has seem to be a configuration needed to be placed to fix the path vs the name (eg. @font url(../media/example.file) becomes @font(name) or @font(media/example.file) when compiled which is relatively incorrect when the browser tries to find the file.