### PR TITLE
Fixes #57: allow for internal bundle dependencies without requiring consuming application to maintain the same dependencies

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -163,7 +163,9 @@ module.exports = function(webpackEnv) {
       filename: (isEnvDemo || isEnvProduction)
         ? 'index.js'
         : isEnvDevelopment && 'static/js/bundle.js', // CRL: update output.filename
+      library: 'mylib', // CRL: add output.library (name for this export)
       libraryTarget: (isEnvDemo || isEnvProduction) ? 'umd' : undefined,  // CRL: Add output.libraryTarget
+      umdNamedDefine: true, // CRL: Add output.umdNamedDefine (control what webpack injects)
       // TODO: remove this when upgrading to webpack 5
       futureEmitAssets: true,
       // There are also additional JS chunk files if you use code splitting.


### PR DESCRIPTION
I created a few different sample projects, using this project as a starting point - and I always seem to run into errors whenever attempting to bundle other libraries within mine (e.g., I want be dependent a form library, but don't want to force that dependency on a consuming application by using a devDependency/peerDependency combination).

As I had noted in issue #53, using libraries which I want to force the consuming application to specify a dependency on is relatively trivial (add to devDependency/peerDependency in my library, and add to the "externals" configuration within your webpack.config file(s).

In this particular case, I couldn't find a way to simply bundle another library without having to go that route - until I realized that I needed to add to the webpack output config (a libraryTarget attribute had already been added, but I needed to also specify library and umdNamedDefine attributes before this all worked for me). Now, I can simply add internal dependencies to my package.json's dependency array, and my consuming application is none the wiser.